### PR TITLE
[PROPINQ-75]: Comunicación del Frontend con el Backend

### DIFF
--- a/src/main/java/com/imaee/propinq/log/config/CorsConfig.java
+++ b/src/main/java/com/imaee/propinq/log/config/CorsConfig.java
@@ -1,0 +1,28 @@
+package com.imaee.propinq.log.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedOrigins)
+                        .allowCredentials(true)
+                        .allowedMethods("*");
+            }
+        };
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -19,3 +19,6 @@ logging:
     org.springframework.web: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+cors:
+  allowed-origins: http://localhost:4200

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,3 +20,6 @@ springdoc:
   swagger-ui:
     disable-swagger-default-url: true
     path: /
+
+cors:
+  allowed-origins: {$CORS_ORIGINS}


### PR DESCRIPTION
## Desarrollo

Se definió la configuración de [CORS](https://developer.mozilla.org/es/docs/Web/HTTP/Guides/CORS) para la comunicación frontend-backend. Esta configuración se realiza en el _backend_ para admitir peticiones HTTP desde el puerto donde se levanta el frontend (4200 en nuestro caso).